### PR TITLE
Fix for wrong type passed to moveTo()

### DIFF
--- a/Factory/UploadedFile.php
+++ b/Factory/UploadedFile.php
@@ -61,7 +61,7 @@ class UploadedFile extends BaseUploadedFile
         $target = $this->getTargetFile($directory, $name);
 
         try {
-            $this->psrUploadedFile->moveTo($target);
+            $this->psrUploadedFile->moveTo((string) $target);
         } catch (\RuntimeException $e) {
             throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, $e->getMessage()), 0, $e);
         }


### PR DESCRIPTION
comment deleted